### PR TITLE
docs: Link voc and vipack to their repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Each option represents a command to run.
 
 There are two ways to build manush.
 
-First is by using vipack package manager. Therefore, the prerequisites are voc (vishap oberon compiler) and vipack (vishap package manager).
+First is by using vipack package manager. Therefore, the prerequisites are [voc](https://github.com/vishaps/voc) (vishap oberon compiler) and [vipack](https://github.com/vishaps/vipack) (vishap package manager).
 
 Issue the following command in manush's directory:
 


### PR DESCRIPTION
This will make it easier for people to navigate to the mentioned projects for installation instructions, etc